### PR TITLE
Soft wrap by default

### DIFF
--- a/settings/language-mediawiki.cson
+++ b/settings/language-mediawiki.cson
@@ -1,3 +1,4 @@
 '.text.html.mediawiki':
   'editor':
     'foldEndPattern': '\\}\\}|\\|}|</(?# stop fold on tag close, and } </)'
+    'softWrap': true


### PR DESCRIPTION
### Why is this change necessary?
- Soft wrap is useful when editing documentation/markdown/wiki files.
- Soft wrap is enabled by default in [atom's core markdown package](https://github.com/atom/language-gfm/blob/master/settings/gfm.cson#L3). It makes sense to do the same for the mediawiki syntax.
### How does it address the issue?
- Sets `'softWrap': true` in `settings/language-mediawiki.cson`.
